### PR TITLE
Crunchy copy refactor

### DIFF
--- a/.github/actions/tf-deploy-composite/action.yml
+++ b/.github/actions/tf-deploy-composite/action.yml
@@ -49,7 +49,7 @@ runs:
         TF_VAR_ASPIRE_AWS_ACCESS_KEY_ID: ${{ inputs.ASPIRE_AWS_ACCESS_KEY_ID }}
         TF_VAR_ASPIRE_AWS_SECRET_ACCESS_KEY: ${{ inputs.ASPIRE_AWS_SECRET_ACCESS_KEY }}
         TF_VAR_GIT_PAT: ${{ inputs.GIT_PAT }}
-        TF_VAR_ASPIRE_BACKEND: ${{ inputs.backend }}
+        TF_VAR_ASPIRE_CLUSTER: ${{ inputs.backend }}
         TF_VAR_SENTRY_DSN: ${{ inputs.SENTRY_DSN }}
         AWS_ACCESS_KEY_ID: ${{ inputs.TERRAFORM_AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.TERRAFORM_AWS_SECRET_ACCESS_KEY }}

--- a/README.md
+++ b/README.md
@@ -40,17 +40,17 @@ export TF_VAR_CRUNCHY_API_KEY=CRUNCHY_API_KEY
 export TF_VAR_ASPIRE_AWS_ACCESS_KEY_ID=YOUR_AWS_ACCESS_KEY
 export TF_VAR_ASPIRE_AWS_SECRET_ACCESS_KEY=YOUR_AWS_SECRET_KEY
 export TF_VAR_GIT_PAT=GIT_PERSONAL_ACCESS_TOKEN
-export TF_VAR_ASPIRE_BACKEND=ASPIRE_BACKEND_TO_RUN_FOR
+export TF_VAR_ASPIRE_CLUSTER=ASPIRE_CLUSTER_TO_RUN_FOR
 export AWS_ACCESS_KEY_ID=TERRAFORM_AWS_ACCESS_KEY
 export AWS_SECRET_ACCESS_KEY=TERRAFORM_AWS_SECRET_KEY
 ```
 
 3. Navigate to the directory in this repository for the region to use for testing (likely `us-east`).
 
-4. Initialize Terraform with the following command, replacing `{ ASPIRE_BACKEND }` with the name of the backend being used for testing (this should match the `TF_VAR_ASPIRE_BACKEND` variable set above):
+4. Initialize Terraform with the following command, replacing `{ ASPIRE_CLUSTER }` with the name of the backend being used for testing (this should match the `TF_VAR_ASPIRE_CLUSTER` variable set above):
 
 ```
-terraform init -backend-config="key={ ASPIRE_BACKEND }/terraform.tfstate"
+terraform init -backend-config="key={ ASPIRE_CLUSTER }/terraform.tfstate"
 ```
 e.g.
 ```
@@ -91,4 +91,3 @@ curl http://169.254.169.254/latest/user-data
 ```
 
 The logs for the Start-Up Script can be found at `/var/log/cloud-init-output.log`.
-

--- a/au/main.tf
+++ b/au/main.tf
@@ -18,6 +18,6 @@ module "crunchy_instance" {
   ASPIRE_AWS_ACCESS_KEY_ID     = var.ASPIRE_AWS_ACCESS_KEY_ID
   ASPIRE_AWS_SECRET_ACCESS_KEY = var.ASPIRE_AWS_SECRET_ACCESS_KEY
   GIT_PAT                      = var.GIT_PAT
-  ASPIRE_BACKEND               = var.ASPIRE_BACKEND
+  ASPIRE_CLUSTER               = var.ASPIRE_CLUSTER
   SENTRY_DSN                   = var.SENTRY_DSN
 }

--- a/au/variables.tf
+++ b/au/variables.tf
@@ -33,7 +33,7 @@ variable "GIT_PAT" {
   default     = ""
 }
 
-variable "ASPIRE_BACKEND" {
+variable "ASPIRE_CLUSTER" {
   description = "The backend to run the script on."
   type        = string
   default     = ""

--- a/modules/crunchy_instance/ec2_setup.tftpl
+++ b/modules/crunchy_instance/ec2_setup.tftpl
@@ -13,7 +13,7 @@ echo "Creating XFS Filesystem on Attached Volume"
 mkfs -t xfs /dev/nvme1n1
 
 echo "Creating new directories"
-mkdir -p "$LOCAL_TEMP_DOWNLOADS_PATH"${ASPIRE_BACKEND}
+mkdir -p "$LOCAL_TEMP_DOWNLOADS_PATH"${ASPIRE_CLUSTER}
 chmod -R 760 $LOCAL_TEMP_DOWNLOADS_PATH
 
 echo "Mounting Attached Volume"
@@ -49,7 +49,7 @@ BASE_S3_PREFIX = "crunchybridge/"
 EOF
 
 echo "Running script..."
-python3 ./src/crunchy_copy.py --backend ${ASPIRE_BACKEND}
+python3 ./src/crunchy_copy.py --cluster ${ASPIRE_CLUSTER}
 
 COUNTER=1
 while true
@@ -60,7 +60,7 @@ do
     -H "Accept: application/vnd.github.v3+json" \
     -H "Authorization: Bearer ${GIT_PAT}" \
     https://api.github.com/repos/aspiredu/crunchy-backups/dispatches \
-    -d '{"event_type": "destroy", "client_payload": {"success": true, "backend": "${ASPIRE_BACKEND}"}}'
+    -d '{"event_type": "destroy", "client_payload": {"success": true, "backend": "${ASPIRE_CLUSTER}"}}'
     sleep 20m
     COUNTER=$[$COUNTER +1]
 done

--- a/modules/crunchy_instance/main.tf
+++ b/modules/crunchy_instance/main.tf
@@ -13,7 +13,7 @@ resource "aws_instance" "cb_backup" {
   security_groups = ["ssh-no-http"]
 
   tags = {
-    Name = "${var.ASPIRE_BACKEND}-pgbackups",
+    Name = "${var.ASPIRE_CLUSTER}-pgbackups",
   }
   user_data = base64encode(templatefile("${path.module}/ec2_setup.tftpl", {
     CRUNCHY_TEAM_ID              = var.CRUNCHY_TEAM_ID
@@ -21,7 +21,7 @@ resource "aws_instance" "cb_backup" {
     ASPIRE_AWS_ACCESS_KEY_ID     = var.ASPIRE_AWS_ACCESS_KEY_ID
     ASPIRE_AWS_SECRET_ACCESS_KEY = var.ASPIRE_AWS_SECRET_ACCESS_KEY
     GIT_PAT                      = var.GIT_PAT
-    ASPIRE_BACKEND               = var.ASPIRE_BACKEND
+    ASPIRE_CLUSTER               = var.ASPIRE_CLUSTER
     SENTRY_DSN                   = var.SENTRY_DSN
   }))
 }
@@ -42,7 +42,7 @@ resource "aws_volume_attachment" "ec2_ebs_att" {
   force_detach = true
 }
 
-output "ASPIRE_BACKEND" {
-  value       = var.ASPIRE_BACKEND
+output "ASPIRE_CLUSTER" {
+  value       = var.ASPIRE_CLUSTER
   description = "The backend the script is being run for."
 }

--- a/modules/crunchy_instance/variables.tf
+++ b/modules/crunchy_instance/variables.tf
@@ -43,7 +43,7 @@ variable "GIT_PAT" {
   default     = ""
 }
 
-variable "ASPIRE_BACKEND" {
+variable "ASPIRE_CLUSTER" {
   description = "The backend to run the script on."
   type        = string
   default     = ""

--- a/src/crunchy_copy.py
+++ b/src/crunchy_copy.py
@@ -241,14 +241,12 @@ class CrunchyCopy:
                     recursive_path_suffixes.append(f"{crunchy_backup_prefix}/{self.backup_target}")
                 else:
                     print("Target backup already exists in AspirEDU S3 Bucket")
-                    signal_dead_mans_snitch(self.cluster["name"])
                     return [], []
             else:
                 print(
                     f"Target backup name {self.backup_target} was not found in list of available"
                     f" CrunchyBridge backups for {self.cluster['name']}"
                 )
-                signal_dead_mans_snitch(self.cluster["name"])
                 return [], []
         else:
             # Determine if there are any new CrunchyBridge backups to move
@@ -269,7 +267,6 @@ class CrunchyCopy:
                     recursive_path_suffixes.append(f"{crunchy_backup_prefix}/{backup['name']}")
             if not has_new_backup:
                 print("No new backups found!! Exiting script :)")
-                signal_dead_mans_snitch(self.cluster["name"])
                 return [], []
         return recursive_path_suffixes, file_path_suffixes
 

--- a/src/crunchy_copy.py
+++ b/src/crunchy_copy.py
@@ -147,8 +147,8 @@ def signal_dead_mans_snitch(cluster: str):
 
 class CrunchyCopy:
     def __init__(self, bucket_name: str, cluster_name: str, backup_target: Optional[str] = None):
-        self.s3, self.s3_client = get_s3(ASPIRE_AWS_ACCESS_KEY_ID, ASPIRE_AWS_SECRET_ACCESS_KEY)
-        self.bucket = self.s3.Bucket(bucket_name)
+        self.s3_resource, self.s3 = get_s3(ASPIRE_AWS_ACCESS_KEY_ID, ASPIRE_AWS_SECRET_ACCESS_KEY)
+        self.bucket = self.s3_resource.Bucket(bucket_name)
         self.backup_target = backup_target
         for cluster in get_crunchy_clusters():
             if cluster["name"] != cluster_name:
@@ -232,7 +232,7 @@ class CrunchyCopy:
         if self.backup_target:
             if self.backup_target in [backup["name"] for backup in self.backup_info["backups"]]:
                 if not backup_exists(
-                    self.s3_client,
+                    self.s3,
                     self.bucket,
                     self.cluster["name"],
                     self.backup_info["stanza"],
@@ -253,7 +253,7 @@ class CrunchyCopy:
             has_new_backup = False
             for backup in self.backup_info["backups"]:
                 if not backup_exists(
-                    self.s3_client,
+                    self.s3,
                     self.bucket,
                     self.cluster["name"],
                     self.backup_info["stanza"],

--- a/us-east/main.tf
+++ b/us-east/main.tf
@@ -18,6 +18,6 @@ module "crunchy_instance" {
   ASPIRE_AWS_ACCESS_KEY_ID     = var.ASPIRE_AWS_ACCESS_KEY_ID
   ASPIRE_AWS_SECRET_ACCESS_KEY = var.ASPIRE_AWS_SECRET_ACCESS_KEY
   GIT_PAT                      = var.GIT_PAT
-  ASPIRE_BACKEND               = var.ASPIRE_BACKEND
+  ASPIRE_CLUSTER               = var.ASPIRE_CLUSTER
   SENTRY_DSN                   = var.SENTRY_DSN
 }

--- a/us-east/variables.tf
+++ b/us-east/variables.tf
@@ -33,7 +33,7 @@ variable "GIT_PAT" {
   default     = ""
 }
 
-variable "ASPIRE_BACKEND" {
+variable "ASPIRE_CLUSTER" {
   description = "The backend to run the script on."
   type        = string
   default     = ""


### PR DESCRIPTION
This reworks the crunchy copy logic into a class to allow for re-use of some properties and splitting out of logic into additional functions. It's still difficult to write tests for because of the tight coupling to AWS and Crunchy Bridge, but this gets us closer to being able to write them.

This should also make it a bit easier for us to refactor the logic to only copy specific files for a backup. It's likely that we need to copy the following:

```
/backup/$CB_STANZA/$CB_BACKUP_NAME/ -> /backup/$CB_STANZA/ 
/backup/$CB_STANZA/backup.info -> /backup/backup.info_$CB_BACKUP_NAME 
/archive/$CB_STANZA/archive.info -> /archive/$CB_STANZA/archive.info_$CB_BACKUP_NAME
```

The naming pattern wouldn't need to be the same, but the concept is still valid.