### PR TITLE
Fix various bugs for crunchy copy process

### DIFF
--- a/src/crunchy_copy.py
+++ b/src/crunchy_copy.py
@@ -22,7 +22,7 @@ CRUNCHY_TEAM_ID = os.getenv("CRUNCHY_TEAM_ID")
 ASPIRE_AWS_ACCESS_KEY_ID = os.getenv("ASPIRE_AWS_ACCESS_KEY_ID")
 ASPIRE_AWS_SECRET_ACCESS_KEY = os.getenv("ASPIRE_AWS_SECRET_ACCESS_KEY")
 
-LOCAL_TEMP_DOWNLOADS_PATH = os.getenv("LOCAL_TEMP_DOWNLOADS_PATH", "temp/")
+LOCAL_TEMP_DOWNLOADS_PATH = os.getenv("LOCAL_TEMP_DOWNLOADS_PATH", "tmp/")
 
 # The v2 directory is necessary so that we can more easily delete the other
 # backups when all have been converted to our the format that either includes

--- a/src/crunchy_copy.py
+++ b/src/crunchy_copy.py
@@ -120,15 +120,14 @@ def upload_all_files_in_dir(source_dir, bucket, prefix):
             bucket.upload_file(
                 os.path.join(root, file),
                 new_file_key,
-                Expires=expiration,
-                StorageClass=STORAGE_CLASS,
+                ExtraArgs={"Expires": expiration, "StorageClass": STORAGE_CLASS},
             )
     return
 
 
 def delete_all_files_in_dir(source_dir):
     print("Cleaning up!!")
-    shutil.rmtree(source_dir)
+    shutil.rmtree(source_dir, ignore_errors=True)
 
 
 def seconds_to_readable(seconds):
@@ -316,9 +315,6 @@ def main():
         description="Moves backups from CrunchyBridge's S3 Buckets to " "AspirEDU's S3 Bucket",
     )
 
-    parser.add_argument(
-        "-b", "--bucket", dest="bucket_name", required=True, help="The name of the bucket."
-    )
     parser.add_argument(
         "-c",
         "--cluster",

--- a/src/crunchy_copy_test.py
+++ b/src/crunchy_copy_test.py
@@ -40,14 +40,18 @@ def test_upload_all_files_in_dir(mocker, patch_storage_class):
         mocker.call(
             "tmp/file.txt",
             "pre-/file.txt",
-            Expires=datetime(2022, 12, 31, 19, 0, tzinfo=edt_tz),
-            StorageClass="TEST_STORAGE",
+            ExtraArgs={
+                "Expires": datetime(2022, 12, 31, 19, 0, tzinfo=edt_tz),
+                "StorageClass": "TEST_STORAGE",
+            },
         ),
         mocker.call(
             "tmp/sub1/file.txt",
             "pre-/sub1/file.txt",
-            Expires=datetime(2022, 12, 31, 19, 0, tzinfo=edt_tz),
-            StorageClass="TEST_STORAGE",
+            ExtraArgs={
+                "Expires": datetime(2022, 12, 31, 19, 0, tzinfo=edt_tz),
+                "StorageClass": "TEST_STORAGE",
+            },
         ),
     ]
 


### PR DESCRIPTION
- Remove bucket as required argument.
- Fixes syntax issue for expiration and storage class.
- Change the default download path to match the gitignore path.