### PR TITLE
Restore the crunchy copy script to working order

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ terraform init -backend-config="key=$TF_VAR_ASPIRE_CLUSTER/terraform.tfstate"
 terraform plan
 ```
 
-7. Run the following command to apply the changes from Step 5 and provision the specified resources from AWS:
+7. Run the following command to apply the changes from Step 6 and provision the specified resources from AWS:
 
 ```
 terraform apply

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pip-compile --upgrade
 terraform --version
 ```
 
-2. Open a new terminal and export the following variables:
+2. Create a new `.env.terraform file` with the following content:
 
 ```
 export TF_VAR_CRUNCHY_TEAM_ID=CRUNCHY_TEAM_ID
@@ -41,39 +41,41 @@ export TF_VAR_ASPIRE_AWS_ACCESS_KEY_ID=YOUR_AWS_ACCESS_KEY
 export TF_VAR_ASPIRE_AWS_SECRET_ACCESS_KEY=YOUR_AWS_SECRET_KEY
 export TF_VAR_GIT_PAT=GIT_PERSONAL_ACCESS_TOKEN
 export TF_VAR_ASPIRE_CLUSTER=ASPIRE_CLUSTER_TO_RUN_FOR
-export AWS_ACCESS_KEY_ID=TERRAFORM_AWS_ACCESS_KEY
-export AWS_SECRET_ACCESS_KEY=TERRAFORM_AWS_SECRET_KEY
+export AWS_ACCESS_KEY_ID="$TF_VAR_ASPIRE_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$TF_VAR_ASPIRE_AWS_SECRET_ACCESS_KEY"
 ```
 
-3. Navigate to the directory in this repository for the region to use for testing (likely `us-east`).
+3. Load the environment variables from the file with the following command:
 
-4. Initialize Terraform with the following command, replacing `{ ASPIRE_CLUSTER }` with the name of the backend being used for testing (this should match the `TF_VAR_ASPIRE_CLUSTER` variable set above):
-
-```
-terraform init -backend-config="key={ ASPIRE_CLUSTER }/terraform.tfstate"
-```
-e.g.
-```
-terraform init -backend-config="key=aspirestaging/terraform.tfstate"
+```shell
+source .env.terraform
 ```
 
-5. (Optional but recommended) Verify the actions Terraform will take when applied with the following command:
+4. Navigate to the directory in this repository for the region to use for testing (likely `us-east`).
+
+5. Initialize Terraform with the following command:
+
+```
+terraform init -backend-config="key=$TF_VAR_ASPIRE_CLUSTER/terraform.tfstate"
+```
+
+6. (Optional but recommended) Verify the actions Terraform will take when applied with the following command:
 
 ```
 terraform plan
 ```
 
-6. Run the following command to apply the changes from Step 5 and provision the specified resources from AWS:
+7. Run the following command to apply the changes from Step 5 and provision the specified resources from AWS:
 
 ```
 terraform apply
 ```
 
-7. The EC2 Instance will be provisioned by Terraform along with the supporting Volume for storage. The state can be viewed through the AWS Web Portal. Connect to the EC2 Instance via SSH (instructions can be found on the AWS Web Portal).
+8. The EC2 Instance will be provisioned by Terraform along with the supporting Volume for storage. The state can be viewed through the AWS Web Portal. Connect to the EC2 Instance via SSH (instructions can be found on the AWS Web Portal).
 
 Note: Accessing the instance via SSH requires the `.pem` private key file corresponding to the AWS Key Pair used by Terraform when provisioning the EC2 instance.
 
-8. Verify the volume was mounted at the correct point in the file structure, verify the file structure itself is as expected, and check that the Python script is running. Here are a few useful commands:
+9. Verify the volume was mounted at the correct point in the file structure, verify the file structure itself is as expected, and check that the Python script is running. Here are a few useful commands:
 
 View Attached Drives with Filesystem and Mount Points
 ```

--- a/modules/crunchy_instance/ec2_setup.tftpl
+++ b/modules/crunchy_instance/ec2_setup.tftpl
@@ -48,7 +48,7 @@ LOCAL_TEMP_DOWNLOADS_PATH = "$LOCAL_TEMP_DOWNLOADS_PATH"
 EOF
 
 echo "Running script..."
-python3 ./src/crunchy_copy.py --cluster ${ASPIRE_CLUSTER}
+python3 -m src.crunchy_copy --cluster ${ASPIRE_CLUSTER}
 
 COUNTER=1
 while true

--- a/modules/crunchy_instance/ec2_setup.tftpl
+++ b/modules/crunchy_instance/ec2_setup.tftpl
@@ -35,7 +35,7 @@ cd $HOME/crunchy-backups/
 pip3 install -r requirements.txt
 
 echo "Creating .env file"
-tee ./bin/.env <<EOF
+tee .env <<EOF
 CRUNCHY_API_KEY = "${CRUNCHY_API_KEY}"
 CRUNCHY_TEAM_ID = "${CRUNCHY_TEAM_ID}"
 


### PR DESCRIPTION
This revises the readme to use a .env file approach for running terraform locally. This also uses a .env file in the project directory in the EC2 instance.