### PR TITLE
Link to various third party services in docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@ A Python script used to transfer backups stored on the CrunchyBridge S3 Bucket t
 
 ## Contributing
 
-Install pre-commit hooks:
-
-```bash
-pre-commit install
-```
-
 Install dependencies
 
 ```bash
 python -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
+```
+
+Install pre-commit hooks:
+
+```bash
+pre-commit install
 ```
 
 ### Updating Python dependencies
@@ -26,7 +26,8 @@ pip-compile --upgrade
 
 ## Testing Locally
 
-1. Ensure the Terraform CLI is installed. The following command should output the currently installed version of the Terraform CLI:
+1. Ensure the [Terraform CLI](https://developer.hashicorp.com/terraform/downloads) is installed. The
+   following command should output the currently installed version of the Terraform CLI:
 
 ```
 terraform --version
@@ -44,6 +45,9 @@ export TF_VAR_ASPIRE_CLUSTER=ASPIRE_CLUSTER_TO_RUN_FOR
 export AWS_ACCESS_KEY_ID="$TF_VAR_ASPIRE_AWS_ACCESS_KEY_ID"
 export AWS_SECRET_ACCESS_KEY="$TF_VAR_ASPIRE_AWS_SECRET_ACCESS_KEY"
 ```
+
+- [AWS access key docs](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_CreateAccessKey)
+- [GitHub Personal Access Token (PAT) docs](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
 
 3. Load the environment variables from the file with the following command:
 

--- a/requirements.in
+++ b/requirements.in
@@ -7,3 +7,4 @@ pip-tools
 time-machine
 pytest
 pytest-mock
+pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,10 +16,18 @@ certifi==2023.7.22
     # via
     #   requests
     #   sentry-sdk
+cfgv==3.4.0
+    # via pre-commit
 charset-normalizer==3.2.0
     # via requests
 click==8.1.7
     # via pip-tools
+distlib==0.3.7
+    # via virtualenv
+filelock==3.12.4
+    # via virtualenv
+identify==2.5.30
+    # via pre-commit
 idna==3.4
     # via requests
 iniconfig==2.0.0
@@ -28,14 +36,20 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
+nodeenv==1.8.0
+    # via pre-commit
 packaging==23.1
     # via
     #   build
     #   pytest
 pip-tools==7.3.0
     # via -r requirements.in
+platformdirs==3.11.0
+    # via virtualenv
 pluggy==1.3.0
     # via pytest
+pre-commit==3.4.0
+    # via -r requirements.in
 pyproject-hooks==1.0.0
     # via build
 pytest==7.4.2
@@ -51,6 +65,8 @@ python-dateutil==2.8.2
     #   time-machine
 python-dotenv==1.0.0
     # via -r requirements.in
+pyyaml==6.0.1
+    # via pre-commit
 requests==2.31.0
     # via -r requirements.in
 s3transfer==0.6.2
@@ -66,6 +82,8 @@ urllib3==1.26.16
     #   botocore
     #   requests
     #   sentry-sdk
+virtualenv==20.24.5
+    # via pre-commit
 wheel==0.41.1
     # via pip-tools
 


### PR DESCRIPTION
Re-arranges the pre-commit installation to after installing the python dependencies because pre-commit is a python dependency.