### PR TITLE
Support running the backup process for a specific day.

### DIFF
--- a/.github/workflows/tf-deploy.yml
+++ b/.github/workflows/tf-deploy.yml
@@ -21,14 +21,9 @@ jobs:
       - name: Get current weekday
         id: weekday
         run: echo "current_day=$(date '+%A')" >> "$GITHUB_OUTPUT"
-      - name: Check weekday
-        if: ${{ steps.weekday.outputs.current_day != 'Saturday' }}
-        run: echo "This job will be skipped because it's not Saturday. It's ${{ steps.weekday.outputs.current_day }}."
       - name: Checkout Commit
-        if: ${{ steps.weekday.outputs.current_day == 'Saturday' }}
         uses: actions/checkout@v3
       - name: Deploy With Terraform
-        if: ${{ steps.weekday.outputs.current_day == 'Saturday' }}
         id: deployAttempt1
         uses: ./.github/actions/tf-deploy-composite
         continue-on-error: true
@@ -46,7 +41,7 @@ jobs:
       - name: Deploy With Terraform Attempt 2
         id: deployAttempt2
         uses: ./.github/actions/tf-deploy-composite
-        if: ${{ steps.weekday.outputs.current_day == 'Saturday' && steps.deployAttempt1.outcome == 'failure' }}
+        if: ${{ steps.deployAttempt1.outcome == 'failure' }}
         continue-on-error: true
         with:
           TERRAFORM_AWS_ACCESS_KEY_ID: ${{ secrets.TERRAFORM_AWS_ACCESS_KEY_ID }}
@@ -62,7 +57,7 @@ jobs:
       - name: Deploy With Terraform Attempt 3
         id: deployAttempt3
         uses: ./.github/actions/tf-deploy-composite
-        if: ${{ steps.weekday.outputs.current_day == 'Saturday' && steps.deployAttempt1.outcome == 'failure' && steps.deployAttempt2.outcome == 'failure' }}
+        if: ${{ steps.deployAttempt1.outcome == 'failure' && steps.deployAttempt2.outcome == 'failure' }}
         continue-on-error: true
         with:
           TERRAFORM_AWS_ACCESS_KEY_ID: ${{ secrets.TERRAFORM_AWS_ACCESS_KEY_ID }}

--- a/modules/crunchy_instance/ec2_setup.tftpl
+++ b/modules/crunchy_instance/ec2_setup.tftpl
@@ -48,7 +48,7 @@ LOCAL_TEMP_DOWNLOADS_PATH = "$LOCAL_TEMP_DOWNLOADS_PATH"
 EOF
 
 echo "Running script..."
-python3 -m src.crunchy_copy --cluster ${ASPIRE_CLUSTER}
+python3 -m src.crunchy_copy --target 20231021 --cluster ${ASPIRE_CLUSTER}
 
 COUNTER=1
 while true


### PR DESCRIPTION
This will need to be merged in since it pulls the repo down. There are too many instances for this to be run serially before the CrunchyBridge window closes.