### PR TITLE
Start database migration process after 10 UTC

### DIFF
--- a/.github/workflows/tf-deploy.yml
+++ b/.github/workflows/tf-deploy.yml
@@ -3,7 +3,7 @@ name: 'Start Script via Terraform'
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 7 * * *' # Every day at 07:00 UTC (03:00 Eastern)
+    - cron: '0 11 * * *' # Every day at 11:00 UTC (07:00 Eastern)
 
 
 jobs:


### PR DESCRIPTION
The aspiredu-au database backups tend to finish about 10 UTC. We should avoid running the process before they are available.

Fixes #26