### PR TITLE
Add Keepalive Job to Cron GitHub Actions

### DIFF
--- a/.github/workflows/tf-deploy.yml
+++ b/.github/workflows/tf-deploy.yml
@@ -75,3 +75,14 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           backend: ${{ matrix.backend }}
           WORKING_DIR: ${{ matrix.working_dir }}
+  keepalive:
+    name: Keepalive Workflow
+    needs: terraform
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gautamkrishnar/keepalive-workflow@v2
+        with:
+          use_api: false


### PR DESCRIPTION
Adds a job that adds a dummy commit to the repo if there hasn't been a change for 50 days preventing GitHub from disabling the Action due to 60 days of inactivity.