### PR TITLE
Remove the Keepalive Action

### DIFF
--- a/.github/workflows/tf-deploy.yml
+++ b/.github/workflows/tf-deploy.yml
@@ -75,16 +75,3 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           backend: ${{ matrix.backend }}
           WORKING_DIR: ${{ matrix.working_dir }}
-  keepalive:
-    name: Keepalive Workflow
-    needs: terraform
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: 'keepalive'
-      - uses: gautamkrishnar/keepalive-workflow@v2
-        with:
-          use_api: false


### PR DESCRIPTION
The Keepalive action we were using to prevent GitHub Actions from being disabled has been removed by GitHub. This removes it from our actions while we work towards a different solution.